### PR TITLE
Implement support for DJ Hero 2 chart features

### DIFF
--- a/Sharktooth/Mub/Mub.cs
+++ b/Sharktooth/Mub/Mub.cs
@@ -87,9 +87,9 @@ namespace Sharktooth.Mub
                 float start = ar.ReadSingle();
                 int mod = ar.ReadInt32();
                 float length = ar.ReadSingle();
-                int wordOffset = ar.ReadInt32();
+                int data = ar.ReadInt32();
 
-                mub.Entries.Add(new MubEntry(start, mod, length, wordOffset > 0 && words.ContainsKey(wordOffset) ? words[wordOffset] : ""));
+                mub.Entries.Add(new MubEntry(start, mod, length, data, data > 0 && words.ContainsKey(data) ? words[data] : ""));
             }
             
             return mub;
@@ -148,7 +148,7 @@ namespace Sharktooth.Mub
                         aw.Write((float)entry.Start);
                         aw.Write((int)entry.Modifier);
                         aw.Write((float)entry.Length);
-                        aw.Write(stringOffsets.ContainsKey(entry.Text) ? stringOffsets[entry.Text] : 0);
+                        aw.Write(stringOffsets.ContainsKey(entry.Text) ? stringOffsets[entry.Text] : entry.Data);
                     }
 
                     // Writes string blob

--- a/Sharktooth/Mub/MubEntry.cs
+++ b/Sharktooth/Mub/MubEntry.cs
@@ -8,19 +8,21 @@ namespace Sharktooth.Mub
 {
     public struct MubEntry
     {
-        public MubEntry(float start, int mod, float length, string text = "")
+        public MubEntry(float start, int mod, float length, int data = 0, string text = "")
         {
             Start = start;
             Modifier = mod;
             Length = length;
+            Data = data;
             Text = text;
         }
 
         public float Start { get; set; } // Measure percentage, 0-index
         public int Modifier { get; set; }
         public float Length { get; set; }
+        public int Data { get; set; }
         public string Text { get; set; }
 
-        public override string ToString() => $"{Start:0.000}, 0x{Modifier:X8}, {Length:0.000}, \"{Text}\"";
+        public override string ToString() => $"{Start:0.000}, 0x{Modifier:X8}, {Length:0.000}, 0x{Data:X8}, \"{Text}\"";
     }
 }

--- a/Sharktooth/Mub/MubExport.cs
+++ b/Sharktooth/Mub/MubExport.cs
@@ -155,6 +155,11 @@ namespace Sharktooth.Mub
                         {
                             track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.Copyright, 0));
                         }
+                        // 0xFFFFFFFF?
+                        else if ((entry.Modifier & 0xFF000000) == 0xFF000000)
+                        {
+                            // ignore
+                        }
                         // Just a section
                         else
                         {

--- a/Sharktooth/Mub/MubExport.cs
+++ b/Sharktooth/Mub/MubExport.cs
@@ -1,9 +1,7 @@
-﻿using System;
+﻿using NAudio.Midi;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NAudio.Midi;
 
 namespace Sharktooth.Mub
 {
@@ -11,6 +9,7 @@ namespace Sharktooth.Mub
     {
         private const int DELTA_TICKS_PER_QUARTER = 480;
         private Mub _mub;
+        private List<MubTempoMarker> tempoMarkers;
 
         public MubExport(Mub mub)
         {
@@ -22,18 +21,98 @@ namespace Sharktooth.Mub
             MidiEventCollection mid = new MidiEventCollection(1, DELTA_TICKS_PER_QUARTER);
             mid.AddTrack(CreateTempoTrack());
             mid.AddTrack(CreateTrack());
+            List<MidiEvent> effectsTrack = CreateEffectsTrack();
+            if (effectsTrack != null)
+                mid.AddTrack(effectsTrack);
 
             MidiFile.Export(path, mid);
+        }
+
+        private long NotePosToTicks(double pos, bool useTempoMarkers = true)
+        {
+            int ticksPerMeasure = DELTA_TICKS_PER_QUARTER * 4; // Assume 4/4
+
+            if (useTempoMarkers && tempoMarkers != null)
+            {
+                for (int i = 0; i < tempoMarkers.Count; ++i)
+                {
+                    if (i == tempoMarkers.Count - 1 || tempoMarkers[i + 1].AbsolutePos > pos)
+                    {
+                        return (long)Math.Round(tempoMarkers[i].GetBeatPos(pos) * ticksPerMeasure);
+                    }
+                }
+                throw new Exception("Error converting note position using tempo markers");
+            }
+            return (long)Math.Round(pos * ticksPerMeasure);
         }
 
         private List<MidiEvent> CreateTempoTrack()
         {
             List<MidiEvent> track = new List<MidiEvent>();
 
+            float chartBPM = 0;
+            int chartUsPerQuarterNote = 500000; // 120 BPM
+
             // These are redundant but ehh
             track.Add(new NAudio.Midi.TextEvent("mubTempo", MetaEventType.SequenceTrackName, 0));
             track.Add(new TimeSignatureEvent(0, 4, 2, 24, 8)); // 4/4 ts
-            track.Add(new TempoEvent(500000, 0)); // 120 bpm
+
+            // get chart BPM
+            foreach (var entry in _mub.Entries)
+            {
+                if (entry.Modifier == 0x0B000002)
+                {
+                    if (chartBPM > 0)
+                    {
+                        throw new Exception("Mub has more than one Chart BPM!");
+                    }
+                    chartBPM = BitConverter.ToSingle(BitConverter.GetBytes(entry.Data), 0);
+                }
+            }
+
+            // without a chart BPM, can't do an accurate tempomap so don't even try without one.
+            if (chartBPM > 0)
+            {
+                chartUsPerQuarterNote = (int)Math.Round(60000000 / chartBPM);
+
+                foreach (var entry in _mub.Entries)
+                {
+                    if (entry.Modifier == 0x0B000001)
+                    {
+                        long start = NotePosToTicks(entry.Start, false);
+                        track.Add(new TempoEvent(entry.Data, start));
+                        if (tempoMarkers == null)
+                        {
+                            tempoMarkers = new List<MubTempoMarker>();
+                        }
+                        tempoMarkers.Add(new MubTempoMarker(entry.Start, entry.Data, chartUsPerQuarterNote));
+                    }
+                }
+                if (tempoMarkers != null)
+                {
+                    tempoMarkers.Sort((x, y) =>
+                    {
+                        if (x.BeatPos < y.BeatPos)
+                            return -1;
+                        else if (x.BeatPos > y.BeatPos)
+                            return 1;
+                        else
+                            return 0;
+                    });
+                    MubTempoMarker temp;
+                    for (int i=1; i<tempoMarkers.Count; ++i)
+                    {
+                        temp = tempoMarkers[i];
+                        temp.AbsolutePos = tempoMarkers[i - 1].GetAbsolutePos(tempoMarkers[i].BeatPos);
+                        tempoMarkers[i] = temp;
+                    }
+                }
+            }
+
+            if (tempoMarkers == null)
+            {
+                track.Add(new TempoEvent(chartUsPerQuarterNote, 0));
+            }
 
             // Adds end track
             track.Add(new MetaEvent(MetaEventType.EndTrack, 0, track.Last().AbsoluteTime));
@@ -45,17 +124,43 @@ namespace Sharktooth.Mub
             List<MidiEvent> track = new List<MidiEvent>();
             track.Add(new NAudio.Midi.TextEvent("NOTES", MetaEventType.SequenceTrackName, 0));
 
-            int ticksPerMeasure = DELTA_TICKS_PER_QUARTER * 4; // Assume 4/4
             foreach (var entry in _mub.Entries)
             {
-                long start = (long)(entry.Start * ticksPerMeasure);
-                long end = (long)(start + (entry.Length * ticksPerMeasure));
+                long start = NotePosToTicks(entry.Start);
+                long end = NotePosToTicks(entry.Start + entry.Length);
+
+                // DJH2 effect type - 0x05FFFFFF through 0x06000009
+                // Should not be added to the notes track
+                if ((entry.Modifier & 0xFF000000) == 0x06000000
+                    || entry.Modifier == 0x05FFFFFF) continue;
+
+                // Add just the Chart BPM text event, ignore the tempo markers
+                if ((entry.Modifier & 0xFF000000) == 0x0B000000)
+                {
+                    if (entry.Modifier == 0x0B000002)
+                    {
+                        float chartBpm = BitConverter.ToSingle(BitConverter.GetBytes(entry.Data), 0);
+                        track.Add(new NAudio.Midi.TextEvent(chartBpm.ToString(), MetaEventType.CuePoint, 0));
+                    }
+                    continue;
+                }
 
                 if ((entry.Modifier & 0xFFFFFF) == 0xFFFFFF)
                 {
-                    // Text event?
+                    // Text Event?
                     if (!string.IsNullOrEmpty(entry.Text))
-                        track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.TextEvent, start));
+                    {
+                        // Author?
+                        if ((entry.Modifier & 0xFF000000) == 0x0A000000)
+                        {
+                            track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.Copyright, 0));
+                        }
+                        // Just a section
+                        else
+                        {
+                            track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.TextEvent, start));
+                        }
+                    }
                     continue;
                 }
 
@@ -63,14 +168,24 @@ namespace Sharktooth.Mub
 
                 if (!string.IsNullOrEmpty(entry.Text))
                 {
-                    if ((entry.Modifier & 0x1000) == 0x1000)
+                    if ((entry.Modifier & 0xFF00) == 0x1000)
                         track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.Lyric, start)); // Lyric event?
                     else
                         track.Add(new NAudio.Midi.TextEvent(entry.Text, MetaEventType.TextEvent, start));
                 }
 
-                track.Add(new NoteEvent(start, 1, MidiCommandCode.NoteOn, entry.Modifier & 0xFF, 100));
-                track.Add(new NoteEvent(end, 1, MidiCommandCode.NoteOff, entry.Modifier & 0xFF, 100));
+                int noteMod = entry.Modifier & 0xFF;
+                int velocity = entry.Data + 1;
+                if (velocity > 127)
+                {
+                    velocity = 127;
+                }
+                else if (velocity < 1)
+                {
+                    velocity = 1;
+                }
+                track.Add(new NoteEvent(start, 1, MidiCommandCode.NoteOn, noteMod, velocity));
+                track.Add(new NoteEvent(end, 1, MidiCommandCode.NoteOff, noteMod, velocity));
             }
 
             track.Sort((x, y) =>
@@ -86,6 +201,59 @@ namespace Sharktooth.Mub
             // Adds end track
             track.Add(new MetaEvent(MetaEventType.EndTrack, 0, track.Last().AbsoluteTime));
             return track;
+        }
+
+        private List<MidiEvent> CreateEffectsTrack()
+        {
+            List<MidiEvent> effects = null;
+
+            foreach (var entry in _mub.Entries)
+            {
+                long start = NotePosToTicks(entry.Start);
+                long end = NotePosToTicks(entry.Start + entry.Length);
+
+                if ((entry.Modifier & 0xFF000000) == 0x06000000 || entry.Modifier == 0x05FFFFFF)
+                {
+                    // Filter effect doesn't actually need an effect note, but sometimes 0x05FFFFFF is used for Filter.
+                    // For the midi, using pitch 0x7F (127) for Filter is good enough.
+                    int effectMod = entry.Modifier & 0x7F;
+                    int velocity = entry.Data + 1;
+                    if (velocity > 127)
+                    {
+                        velocity = 127;
+                    }
+                    else if (velocity < 1)
+                    {
+                        velocity = 1;
+                    }
+
+                    if (effects == null)
+                    {
+                        effects = new List<MidiEvent>();
+                        effects.Add(new NAudio.Midi.TextEvent("EFFECTS", MetaEventType.SequenceTrackName, 0));
+                    }
+                    effects.Add(new NoteEvent(start, 1, MidiCommandCode.NoteOn, effectMod, velocity));
+                    effects.Add(new NoteEvent(end, 1, MidiCommandCode.NoteOff, effectMod, velocity));
+                    continue;
+                }
+            }
+
+            if (effects != null)
+            {
+                effects.Sort((x, y) =>
+                {
+                    if (x.AbsoluteTime < y.AbsoluteTime)
+                        return -1;
+                    else if (x.AbsoluteTime > y.AbsoluteTime)
+                        return 1;
+                    else
+                        return 0;
+                });
+
+                // Adds end track
+                effects.Add(new MetaEvent(MetaEventType.EndTrack, 0, effects.Last().AbsoluteTime));
+            }
+            return effects;
         }
     }
 }

--- a/Sharktooth/Mub/MubImport.cs
+++ b/Sharktooth/Mub/MubImport.cs
@@ -185,6 +185,12 @@ namespace Sharktooth.Mub
                 }
             }
 
+            // 0xFFFFFFFF note at beginning of chart needed for DJH2 Beginner charts
+            mubNotes.Add(new MubEntry(0.0f,
+                                -1, // 0xFFFFFFFF
+                                0.0f,
+                                0));
+
             var notes = noteTrack
                 .Where(x => x is NoteOnEvent)
                 .Select(x => x as NoteOnEvent);

--- a/Sharktooth/Mub/MubTempoMarker.cs
+++ b/Sharktooth/Mub/MubTempoMarker.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sharktooth.Mub
+{
+    public struct MubTempoMarker
+    {
+        public MubTempoMarker(double beatPos, int usPerQuarterNote, int chartUsPerQuarterNote)
+        {
+            ChartUsPerQuarterNote = chartUsPerQuarterNote;
+            UsPerQuarterNote = usPerQuarterNote;
+            BeatPos = beatPos;
+            AbsolutePos = beatPos;
+        }
+
+        public int ChartUsPerQuarterNote { get; }
+        public int UsPerQuarterNote { get; }
+        public double BeatPos { set;  get; }
+        public double AbsolutePos { set; get; }
+
+        public double GetBeatPos(double notePos)
+        {
+            return BeatPos + (notePos - AbsolutePos) * ChartUsPerQuarterNote / UsPerQuarterNote;
+        }
+
+        public double GetAbsolutePos(double notePos)
+        {
+            return AbsolutePos + (notePos - BeatPos) * UsPerQuarterNote / ChartUsPerQuarterNote;
+        }
+    }
+}

--- a/Sharktooth/Sharktooth.csproj
+++ b/Sharktooth/Sharktooth.csproj
@@ -58,6 +58,7 @@
     <Compile Include="FarEntry.cs" />
     <Compile Include="Global.cs" />
     <Compile Include="MidiMapping.cs" />
+    <Compile Include="Mub\MubTempoMarker.cs" />
     <Compile Include="Mub\MubExport.cs" />
     <Compile Include="Mub\Mub.cs" />
     <Compile Include="Mub\MubEntry.cs" />


### PR DESCRIPTION
BPM & Tempomap, and the infrastructure needed to convert the single-bpm-based Mub positions to proper tempo-based Midi positions.
Chart author, implemented using a Cue textevent
Effect types, implemented using a separate EFFECTS track
Note Velocity ~~& Midi channels~~, for freestyle sample selection ~~& partial Scene/VisualMarkup support~~

All features used by DJH2 note charts are implemented.
Scene/VisualMarkup support is incomplete as some channels have note pitches higher than 127.