### PR TITLE
DJH2 Lyrics support and other DJH fixes

### DIFF
--- a/Sharktooth/Mub/MubExport.cs
+++ b/Sharktooth/Mub/MubExport.cs
@@ -53,8 +53,6 @@ namespace Sharktooth.Mub
             float chartBPM = 0;
             int chartUsPerQuarterNote = 500000; // 120 BPM
 
-            // These are redundant but ehh
-            track.Add(new NAudio.Midi.TextEvent("mubTempo", MetaEventType.SequenceTrackName, 0));
             track.Add(new TimeSignatureEvent(0, 4, 2, 24, 8)); // 4/4 ts
 
             // get chart BPM


### PR DESCRIPTION
Add support for DJH2 lyrics
- Lyric note conversion
- LYRIC_PAGE and LYRIC_COLOR markers
Better handling of unknown note types
Always export an EFFECTS track, to workaround a bug in REAPER that adds the tempo track name to the NOTES track